### PR TITLE
Add alias expansion for tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -79,7 +79,12 @@ module.exports = {
   moduleFileExtensions: ['js', 'jsx'],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    '^App(.*)$': '<rootDir>/client/src/components/App$1',
+    '^Overview(.*)$': '<rootDir>/client/src/components/Overview$1',
+    '^RelatedItems(.*)$': '<rootDir>/client/src/components/RelatedItems$1',
+    '^Reviews(.*)$': '<rootDir>/client/src/components/Reviews$1',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build:dev": "webpack --mode=development --watch",
     "start": "node server/index.js",
     "start:dev": "NODE_ENV=development nodemon server/index.js",
-    "test": "jest",
+    "test": "jest --silent=false",
     "test:ci": "jest --maxWorkers=2"
   },
   "dependencies": {


### PR DESCRIPTION
Also adds the `--silent=false` flag to our test script to allow for viewing of `console.log`s in the test output.

This worked for me when I expanded `'App/...'`. Let me know if you have any issues.