### PR TITLE
ci: generate coverage badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: coverage
 
 on:
   push:
-    branches: [ main ]
+    branches: [ coverage ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
         label: coverage
         message: ${{ env.COVERAGE }}
         namedLogo: jest
-        logoColor: "#C21325"
+        logoColor: white
         valColorRange: ${{ env.COVERAGE }}
         maxColorRange: 100
         minColorRange: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Generate coverage report
       run:  |
         SUMMARY="$(npm test --coverage --coverageReporters=text-summary | tail -3 | head -1)"
-        TOKENS=($SUMMARY)      echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
+        TOKENS=($SUMMARY)      
+        echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge
       uses: schneegans/dynamic-badges-action@v1.4.0
       with:
@@ -36,7 +37,7 @@ jobs:
         message: ${{ env.COVERAGE }}
         namedLogo: jest
         logoColor: "#C21325"
-        valColorRange: ${{ env.ANSWER }}
+        valColorRange: ${{ env.COVERAGE }}
         maxColorRange: 100
         minColorRange: 0
         style: flat

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,43 @@
+name: coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16.x'
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run build
+    - name: Generate coverage report
+      run: |
+      SUMMARY="$(npm test -- --coverageReporters='text-summary' | tail -2 | head -1)"
+      TOKENS=($SUMMARY)
+      echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
+    - name: Create Coverage Badge
+      uses: schneegans/dynamic-badges-action@v1.1.0
+      with:
+        auth: ${{ secrets.GIST_SECRET }}
+        gistID: 543788f5251dd639ee579c24fba7a2a4
+        filename: SERUM_coverage.json
+        label: coverage
+        message: ${{ env.COVERAGE }}
+        namedLogo: jest
+        logoColor: "#C21325"
+        valColorRange: ${{ env.ANSWER }}
+        maxColorRange: 100
+        minColorRange: 0
+        style: flat

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,8 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
+    - name: Build
+      run: npm run build
     - name: Generate coverage report
       run:  |
         SUMMARY="$(npm test:ci -- --coverageReporters='text-summary' | tail -3 | head -1)"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
         SUMMARY="$(npm test --coverage --coverageReporters=text-summary | tail -3 | head -1)"
         TOKENS=($SUMMARY)      echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge
-      uses: schneegans/dynamic-badges-action@v1.1.0
+      uses: schneegans/dynamic-badges-action@v1.4.0
       with:
         auth: ${{ secrets.GIST_SECRET }}
         gistID: 543788f5251dd639ee579c24fba7a2a4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
       run: npm run build
     - name: Generate coverage report
       run:  |
-        SUMMARY="$(npm test --coverage --coverageReporters=text-summary | tail -3 | head -1)"
+        SUMMARY="$(npm test --coverage --coverageReporters='text-summary' | tail -3 | head -1)"
         TOKENS=($SUMMARY)      
         echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,6 @@ name: coverage
 on:
   push:
     branches: [ coverage ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:
@@ -20,13 +18,9 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
-    - name: Build
-      run: npm run build
-    - name: Test
-      run: npm test -- --coverageReporters='text-summary'
     - name: Generate coverage report
       run:  |
-        SUMMARY="$(npm test -- --coverageReporters='text-summary' | tail -3 | head -1)"
+        SUMMARY="$(npm test:ci -- --coverageReporters='text-summary' | tail -3 | head -1)"
         TOKENS=($SUMMARY)      
         echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,10 +23,9 @@ jobs:
     - name: Build
       run: npm run build
     - name: Generate coverage report
-      run: |
-      SUMMARY="$(npm test -- --coverageReporters='text-summary' | tail -2 | head -1)"
-      TOKENS=($SUMMARY)
-      echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
+      run:  |
+        SUMMARY="$(npm test --coverage --coverageReporters=text-summary | tail -3 | head -1)"
+        TOKENS=($SUMMARY)      echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge
       uses: schneegans/dynamic-badges-action@v1.1.0
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,11 +18,9 @@ jobs:
         cache: 'npm'
     - name: Install dependencies
       run: npm ci
-    - name: Build
-      run: npm run build
     - name: Generate coverage report
       run:  |
-        SUMMARY="$(npm test:ci -- --coverageReporters='text-summary' | tail -3 | head -1)"
+        SUMMARY="$(npm run test:ci -- --coverageReporters='text-summary' | tail -3 | head -1)"
         TOKENS=($SUMMARY)      
         echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@ name: coverage
 
 on:
   push:
-    branches: [ coverage ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,9 +22,11 @@ jobs:
       run: npm ci
     - name: Build
       run: npm run build
+    - name: Test
+      run: npm test -- --coverageReporters='text-summary'
     - name: Generate coverage report
       run:  |
-        SUMMARY="$(npm test --coverage --coverageReporters='text-summary' | tail -3 | head -1)"
+        SUMMARY="$(npm test -- --coverageReporters='text-summary' | tail -3 | head -1)"
         TOKENS=($SUMMARY)      
         echo "COVERAGE=$(echo ${TOKENS[2]})" >> $GITHUB_ENV
     - name: Create Coverage Badge

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Serum
 
 ![build](https://github.com/FECTeamOne/Serum/actions/workflows/tests.yml/badge.svg)
-![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/slargman/543788f5251dd639ee579c24fba7a2a4/raw/670635928fef416a8d99fc62ad46d8fcc857b6ce/SERUM_coverage.json)
+![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/slargman/543788f5251dd639ee579c24fba7a2a4/raw/SERUM_coverage.json)
 
 Serum is an ecommerce product detail page built for a fictional clothing company as an exercise in front-end development. It contains three modules: an overview, a ratings and reviews section, and a related items and comparison section.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Serum
 
 ![build](https://github.com/FECTeamOne/Serum/actions/workflows/tests.yml/badge.svg)
+![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/slargman/543788f5251dd639ee579c24fba7a2a4/raw/SERUM_coverage.json)
 
 Serum is an ecommerce product detail page built for a fictional clothing company as an exercise in front-end development. It contains three modules: an overview, a ratings and reviews section, and a related items and comparison section.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Serum
 
 ![build](https://github.com/FECTeamOne/Serum/actions/workflows/tests.yml/badge.svg)
-![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/slargman/543788f5251dd639ee579c24fba7a2a4/raw/SERUM_coverage.json)
+![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/slargman/543788f5251dd639ee579c24fba7a2a4/raw/670635928fef416a8d99fc62ad46d8fcc857b6ce/SERUM_coverage.json)
 
 Serum is an ecommerce product detail page built for a fictional clothing company as an exercise in front-end development. It contains three modules: an overview, a ratings and reviews section, and a related items and comparison section.
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "start": "node server/index.js",
     "start:dev": "NODE_ENV=development nodemon server/index.js",
     "test": "jest --silent=false",
-    "test:ci": "jest --maxWorkers=2"
+    "test:ci": "jest --coverage --maxWorkers=2"
   },
   "dependencies": {
     "axios": "^0.27.2",


### PR DESCRIPTION
Adds a github workflow that uses the code coverage reports from jest to generate a badge that updates on pushes (i.e. PR merge) to main.