### PR TITLE
feat: make Carousel a controlled component

### DIFF
--- a/client/src/assets/ArrowIcon.jsx
+++ b/client/src/assets/ArrowIcon.jsx
@@ -1,16 +1,27 @@
 import React from 'react';
+import styled from 'styled-components';
 import Icon from 'assets/Icon.jsx';
 
-/**
- * A wedge arrow icon
- */
+const Svg = styled(Icon)`
+  path,
+  polygon,
+  rect {
+    fill: var(--color-main);
+  }
+
+  circle {
+    stroke: var(--color-main);
+    stroke-width: 1;
+  }
+
+`;
+
 function ArrowIcon(props) {
   return (
-    <Icon viewBox="0 0 20 20" {...props}>
+    <Svg viewBox="0 0 20 20" {...props}>
       <path fill="none" d="M11.611,10.049l-4.76-4.873c-0.303-0.31-0.297-0.804,0.012-1.105c0.309-0.304,0.803-0.293,1.105,0.012l5.306,5.433c0.304,0.31,0.296,0.805-0.012,1.105L7.83,15.928c-0.152,0.148-0.35,0.223-0.547,0.223c-0.203,0-0.406-0.08-0.559-0.236c-0.303-0.309-0.295-0.803,0.012-1.104L11.611,10.049z" />
-    </Icon>
-  )
-};
+    </Svg>
+  );
+}
 
 export default ArrowIcon;
-

--- a/client/src/assets/Icon.jsx
+++ b/client/src/assets/Icon.jsx
@@ -14,17 +14,6 @@ const Icon = styled.svg.attrs({
   width: ${({ iconWidth }) => iconWidth || '1em'};
   height: ${({ iconHeight }) => iconHeight || '1em'};
   transform: ${({ rotation }) => (rotation ? `rotate(${rotation * 90}deg)` : '')};
-
-  path,
-  polygon,
-  rect {
-    fill: var(--color-main);
-  }
-
-  circle {
-    stroke: var(--color-main);
-    stroke-width: 1;
-  }
 `;
 
 Icon.propTypes = {
@@ -36,7 +25,7 @@ Icon.propTypes = {
   rotation: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string,
-  ]);
+  ]),
 };
 
 export default Icon;

--- a/client/src/components/shared/Carousel.jsx
+++ b/client/src/components/shared/Carousel.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Button from 'shared/Button.jsx';
+import ArrowIcon from 'assets/ArrowIcon.jsx';
+
+const StyledCarousel = styled.div`
+  display: flex;
+  flex-direction: ${({ direction }) => direction};
+  gap: ${({ gap }) => gap};
+`;
+
+const CarouselItem = styled.div`
+  display: ${({ visible }) => (visible ? '' : 'none')};
+`;
+
+const CarouselButton = styled(Button)`
+  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+`;
+
+// TODO: update docs
+/**
+ * Displays a set of items with buttons to scroll through them
+ * @param {Array}  items The items to be displayed
+ * @param {Number} size  How many items to display at once
+ */
+function Carousel({
+  items,
+  size,
+  scrollIndex,
+  direction = 'row',
+  arrowWidth,
+  arrowHeight,
+  handleScroll = () => {},
+}) {
+  const placeInRange = (index) => {
+    const adjustedIndex = Math.min(index, items.length - size + 1);
+    return Math.max(0, adjustedIndex);
+  };
+
+  const adjustedScrollIndex = placeInRange(scrollIndex);
+
+  return (
+    <StyledCarousel direction={direction}>
+
+      <CarouselButton
+        type="button"
+        onClick={() => { handleScroll(placeInRange(adjustedScrollIndex - size), size); }}
+        visible={adjustedScrollIndex !== 0}
+      >
+
+        <ArrowIcon
+          iconWidth={arrowWidth}
+          iconHeight={arrowHeight}
+          rotation={2 + Number(direction === 'column')}
+        />
+
+      </CarouselButton>
+
+      {items.map((item, i) => (
+        <CarouselItem
+          visible={adjustedScrollIndex <= i && i < adjustedScrollIndex + size}
+          key={item.key}
+        >
+          {item}
+        </CarouselItem>
+      ))}
+
+      <CarouselButton
+        type="button"
+        onClick={() => { handleScroll(placeInRange(adjustedScrollIndex + size), size); }}
+        visible={adjustedScrollIndex < items.length - size}
+      >
+
+        <ArrowIcon
+          iconWidth={arrowWidth}
+          iconHeight={arrowHeight}
+          rotation={Number(direction === 'column')}
+        />
+
+      </CarouselButton>
+
+    </StyledCarousel>
+  );
+}
+
+Carousel.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.element).isRequired,
+  size: PropTypes.number.isRequired,
+  direction: PropTypes.string,
+};
+
+export default Carousel;

--- a/client/src/components/shared/Carousel.jsx
+++ b/client/src/components/shared/Carousel.jsx
@@ -4,34 +4,17 @@ import styled from 'styled-components';
 import Button from 'shared/Button.jsx';
 import ArrowIcon from 'assets/ArrowIcon.jsx';
 
-const StyledCarousel = styled.div`
-  display: flex;
-  flex-direction: ${({ direction }) => direction};
-  gap: ${({ gap }) => gap};
-`;
-
-const CarouselItem = styled.div`
-  display: ${({ visible }) => (visible ? '' : 'none')};
-`;
-
-const CarouselButton = styled(Button)`
-  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
-`;
-
-// TODO: update docs
 /**
  * Displays a set of items with buttons to scroll through them
- * @param {Array}  items The items to be displayed
- * @param {Number} size  How many items to display at once
  */
 function Carousel({
   items,
   size,
   scrollIndex,
-  direction = 'row',
+  handleScroll,
+  direction,
   arrowWidth,
   arrowHeight,
-  handleScroll = () => {},
 }) {
   const placeInRange = (index) => {
     const adjustedIndex = Math.min(index, items.length - size + 1);
@@ -48,13 +31,11 @@ function Carousel({
         onClick={() => { handleScroll(placeInRange(adjustedScrollIndex - size), size); }}
         visible={adjustedScrollIndex !== 0}
       >
-
         <ArrowIcon
           iconWidth={arrowWidth}
           iconHeight={arrowHeight}
           rotation={2 + Number(direction === 'column')}
         />
-
       </CarouselButton>
 
       {items.map((item, i) => (
@@ -71,13 +52,11 @@ function Carousel({
         onClick={() => { handleScroll(placeInRange(adjustedScrollIndex + size), size); }}
         visible={adjustedScrollIndex < items.length - size}
       >
-
         <ArrowIcon
           iconWidth={arrowWidth}
           iconHeight={arrowHeight}
           rotation={Number(direction === 'column')}
         />
-
       </CarouselButton>
 
     </StyledCarousel>
@@ -85,9 +64,60 @@ function Carousel({
 }
 
 Carousel.propTypes = {
+  /** The items to be displayed in the carousel */
   items: PropTypes.arrayOf(PropTypes.element).isRequired,
+  /** How many items to display at once */
   size: PropTypes.number.isRequired,
+  /** The index in items of the first item that should appear in the
+   * carousel. This prop should be used to make Carousel behave as a
+   * controlled component.
+   */
+  scrollIndex: PropTypes.number.isRequired,
+  /**
+   * Function to be called when one of the carousel buttons is
+   * clicked and the carousel should scroll. When this occurs
+   * handleScroll is called with two arguments: index and size. Index
+   * is the value that scrollIndex should take to reflect the button
+   * click and size is the value of size, provided for convenience.
+   * Passing handleScroll the following function suffices to provide
+   * the basic carousel behavior: (index) => { setScrollIndex(index); },
+   * where setScrollIndex is the setter for the state variable passed
+   * to scrollIndex.
+   */
+  handleScroll: PropTypes.func.isRequired,
+  /**
+   * Carousel direction. Use 'row' for horizontal and 'column' for
+   * vertical.
+   */
   direction: PropTypes.string,
+  /**
+   * Width to be used for the arrow icon, e.g. "100px" or "var(--size-3)"
+   */
+  arrowWidth: PropTypes.string,
+  /**
+   * Height to be used for the arrow icon, e.g. "100px" or "var(--size-3)"
+   */
+  arrowHeight: PropTypes.string,
 };
+
+Carousel.defaultProps = {
+  direction: 'row',
+  arrowWidth: 'var(--size-2)',
+  arrowHeight: 'var(--size-2)',
+};
+
+const StyledCarousel = styled.div`
+  display: flex;
+  flex-direction: ${({ direction }) => direction};
+  gap: ${({ gap }) => gap};
+`;
+
+const CarouselItem = styled.div`
+  display: ${({ visible }) => (visible ? '' : 'none')};
+`;
+
+const CarouselButton = styled(Button)`
+  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+`;
 
 export default Carousel;

--- a/client/src/components/shared/Carousel.jsx
+++ b/client/src/components/shared/Carousel.jsx
@@ -10,8 +10,9 @@ import ArrowIcon from 'assets/ArrowIcon.jsx';
 function Carousel({
   items,
   size,
+  label,
   scrollIndex,
-  handleScroll,
+  onScroll,
   direction,
   arrowWidth,
   arrowHeight,
@@ -28,7 +29,8 @@ function Carousel({
 
       <CarouselButton
         type="button"
-        onClick={() => { handleScroll(placeInRange(adjustedScrollIndex - size), size); }}
+        aria-label={`Back button for ${label} carousel`}
+        onClick={() => { onScroll(placeInRange(adjustedScrollIndex - size), size); }}
         visible={adjustedScrollIndex !== 0}
       >
         <ArrowIcon
@@ -49,7 +51,8 @@ function Carousel({
 
       <CarouselButton
         type="button"
-        onClick={() => { handleScroll(placeInRange(adjustedScrollIndex + size), size); }}
+        aria-label={`Forward button for ${label} carousel`}
+        onClick={() => { onScroll(placeInRange(adjustedScrollIndex + size), size); }}
         visible={adjustedScrollIndex < items.length - size}
       >
         <ArrowIcon
@@ -68,6 +71,11 @@ Carousel.propTypes = {
   items: PropTypes.arrayOf(PropTypes.element).isRequired,
   /** How many items to display at once */
   size: PropTypes.number.isRequired,
+  /**
+   * Accessibility label for carousel. Used to interpolate aria-labels
+   * for the forward and back buttons
+   */
+  label: PropTypes.string.isRequired,
   /** The index in items of the first item that should appear in the
    * carousel. This prop should be used to make Carousel behave as a
    * controlled component.
@@ -76,15 +84,15 @@ Carousel.propTypes = {
   /**
    * Function to be called when one of the carousel buttons is
    * clicked and the carousel should scroll. When this occurs
-   * handleScroll is called with two arguments: index and size. Index
+   * onScroll is called with two arguments: index and size. Index
    * is the value that scrollIndex should take to reflect the button
    * click and size is the value of size, provided for convenience.
-   * Passing handleScroll the following function suffices to provide
+   * Passing hand(eScroll the following function suffices to provide
    * the basic carousel behavior: (index) => { setScrollIndex(index); },
    * where setScrollIndex is the setter for the state variable passed
    * to scrollIndex.
    */
-  handleScroll: PropTypes.func.isRequired,
+  onScroll: PropTypes.func.isRequired,
   /**
    * Carousel direction. Use 'row' for horizontal and 'column' for
    * vertical.

--- a/client/src/components/shared/Carousel.test.jsx
+++ b/client/src/components/shared/Carousel.test.jsx
@@ -2,63 +2,154 @@ import { screen } from '@testing-library/react';
 import Carousel from 'shared/Carousel.jsx';
 
 describe('Carousel', () => {
-
-  // TODO: refactor tests to remove nesting
   const range = (start, end) => (
     Array(end - start + 1).fill().map((_, i) => i + start)
   );
 
-  const numbers = range(0, 9);
-  const size = 4;
-
-  const getScreenItems = () => {
-    const screenItems = [];
-    numbers.forEach(i => {
-      const screenItem = screen.queryByText(new RegExp(`^${i}$`));
-      if (screenItem) {
-        screenItems.push(screenItem);
-      }
-    });
-    return screenItems;
-  };
-
-  const checkScreenItems = (bounds) => {
-    numbers.forEach(i => {
-      const screenItem = screen.queryByText(new RegExp(`^${i}$`));
-      if (bounds.includes(i)) {
-        expect(screenItem).toBeVisible();
-      } else {
-        expect(screenItem).toBeNull();
-      }
-    });
-  };
-
-  beforeEach(() => {
-    const items = numbers.map(i => (
-      <div key={i}>{i}</div>
-    ));
+  it('should show the correct number of items', () => {
+    const numbers = range(0, 9);
 
     render(
-      <Carousel items={items} size={size} />
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={0}
+        onScroll={() => {}}
+      />
     );
+
+    numbers.forEach((i) => {
+      const carouselItem = screen.queryByText(new RegExp(`^${i}$`));
+      if (i >= 0 && i < 4) {
+        expect(carouselItem).toBeVisible();
+      } else {
+        expect(carouselItem).not.toBeVisible();
+      }
+    });
   });
 
-  it('should show the correct number of items', () => {
-    let screenItems = getScreenItems();
-    expect(screenItems.length).toEqual(size);
+  it('should not show the back button at the beginning of the carousel', () => {
+    const numbers = range(0, 5);
+
+    render(
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={0}
+        onScroll={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/back/i)).not.toBeVisible();
+    expect(screen.getByRole('button', { name: /forward/i })).toBeVisible();
   });
 
-  it('should scroll on button presses', async () => {
+  it('should not show the forward button at the beginning of the carousel', () => {
+    const numbers = range(0, 5);
+
+    render(
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={2}
+        onScroll={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText(/forward/i)).not.toBeVisible();
+    expect(screen.getByRole('button', { name: /back/i })).toBeVisible();
+  });
+
+  it('should scroll forward on button press', async () => {
     const user = userEvent.setup();
-    const backButton = screen.getByText('<');
-    const forwardButton = screen.getByText('>');
+    const numbers = range(0, 9);
+    let scrollIndex = 0;
 
-    await user.click(forwardButton);
-    checkScreenItems(range(size, 2 * size - 1));
+    const { rerender } = render(
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={scrollIndex}
+        onScroll={(index) => { scrollIndex = index; }}
+      />
+    );
 
-    await user.click(backButton);
-    checkScreenItems(range(0, size - 1));
+    await user.click(screen.getByRole('button', { name: /forward/i }));
+
+    rerender(
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={scrollIndex}
+        onScroll={(index) => { scrollIndex = index; }}
+      />
+    );
+
+    for (const i of numbers) {
+      const carouselItem = screen.queryByText(new RegExp(`^${i}$`));
+      if (i >= 4 && i < 8) {
+        await waitFor(() => { expect(carouselItem).toBeVisible();});
+      } else {
+        await waitFor(() => { expect(carouselItem).not.toBeVisible();});
+      }
+    }
   });
 
-  it.todo('should not show the appropriate buttons at corresponding end ranges');
+   it('should scroll backward on button press', async () => {
+    const user = userEvent.setup();
+    const numbers = range(0, 9);
+    let scrollIndex = 4;
+
+    const { rerender } = render(
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={scrollIndex}
+        onScroll={(index) => { scrollIndex = index; }}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /back/i }));
+
+    rerender(
+      <Carousel
+        items={numbers.map((i) => (
+          <div key={i}>{i}</div>
+        ))}
+        label="test"
+        size={4}
+        scrollIndex={scrollIndex}
+        onScroll={(index) => { scrollIndex = index; }}
+      />
+    );
+
+    for (const i of numbers) {
+      const carouselItem = screen.queryByText(new RegExp(`^${i}$`));
+      if (i >= 0 && i < 4) {
+        await waitFor(() => { expect(carouselItem).toBeVisible();});
+      } else {
+        await waitFor(() => { expect(carouselItem).not.toBeVisible();});
+      }
+    }
+  });
+
+
 });

--- a/client/src/components/shared/Carousel.test.jsx
+++ b/client/src/components/shared/Carousel.test.jsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react';
+import Carousel from 'shared/Carousel.jsx';
+
+describe('Carousel', () => {
+
+  // TODO: refactor tests to remove nesting
+  const range = (start, end) => (
+    Array(end - start + 1).fill().map((_, i) => i + start)
+  );
+
+  const numbers = range(0, 9);
+  const size = 4;
+
+  const getScreenItems = () => {
+    const screenItems = [];
+    numbers.forEach(i => {
+      const screenItem = screen.queryByText(new RegExp(`^${i}$`));
+      if (screenItem) {
+        screenItems.push(screenItem);
+      }
+    });
+    return screenItems;
+  };
+
+  const checkScreenItems = (bounds) => {
+    numbers.forEach(i => {
+      const screenItem = screen.queryByText(new RegExp(`^${i}$`));
+      if (bounds.includes(i)) {
+        expect(screenItem).toBeVisible();
+      } else {
+        expect(screenItem).toBeNull();
+      }
+    });
+  };
+
+  beforeEach(() => {
+    const items = numbers.map(i => (
+      <div key={i}>{i}</div>
+    ));
+
+    render(
+      <Carousel items={items} size={size} />
+    );
+  });
+
+  it('should show the correct number of items', () => {
+    let screenItems = getScreenItems();
+    expect(screenItems.length).toEqual(size);
+  });
+
+  it('should scroll on button presses', async () => {
+    const user = userEvent.setup();
+    const backButton = screen.getByText('<');
+    const forwardButton = screen.getByText('>');
+
+    await user.click(forwardButton);
+    checkScreenItems(range(size, 2 * size - 1));
+
+    await user.click(backButton);
+    checkScreenItems(range(0, size - 1));
+  });
+
+  it.todo('should not show the appropriate buttons at corresponding end ranges');
+});

--- a/client/src/tests/testSetup.js
+++ b/client/src/tests/testSetup.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import { render, getAllByRole } from '@testing-library/react';
+import { render, getAllByRole, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import testData from 'tests/testData.js';
 
 global.React = React;
 global.render = render;
 global.getAllByRole = getAllByRole;
+global.waitFor = waitFor;
 global.userEvent = userEvent;
 global.testData = testData;


### PR DESCRIPTION
Switches `Carousel` to follow a controlled component paradigm. The props `scrollIndex` and `onScroll` are used to achieve this.

`scrollIndex` tells `Carousel` the index of the first element from `items` that it should display. The number of subsequent items to be displayed is then determined by `size`.

The `onScroll` prop takes a function and is used to provide `Carousel` with an event handler that can inform the parent component of clicks to the buttons in `Carousel`. `Carousel` reports what `scrollIndex` should be to reflect the change represented by the button clicks by passing this value to the `onScroll` handler. That is, a button click triggers a call to `onScroll` with the argument `index`, where `index` reflects the value `scrollIndex` should take to reflect the button click.

These changes were necessary in order to enable the programmatic control of the `Carousel`, e.g. changes to `Carousel` that should be triggered by user interaction in a different component.